### PR TITLE
made import of module work with PS 7

### DIFF
--- a/Modules/MediaTool/WimGapi.ps1
+++ b/Modules/MediaTool/WimGapi.ps1
@@ -912,7 +912,7 @@ namespace WIMInterop {
 
 if (-not ([System.Management.Automation.PSTypeName]'WIMInterop.WimFile').Type)
 {
-    Add-Type -TypeDefinition $code -ReferencedAssemblies "System.Xml","System.Linq","System.Xml.Linq"
+    Add-Type -TypeDefinition $code -ReferencedAssemblies "Microsoft.Win32.Primitives","System.Collections","System.Core","System.Text.RegularExpressions","System.Xml","System.Xml.XDocument","System.Xml.XPath.XDocument","System.Linq","System.Xml.Linq"
 }
 
 function Get-WimFileImagesInfo


### PR DESCRIPTION
I had a problem importing the module using

```shell
Import-Module .\MediaTool\Modules\MediaTool
```

I added referenced assemblies until I could it import without any errors.

I work with PowerShell 7.5 btw.